### PR TITLE
Add instructions and rules overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
     <img src="trekkerspel_banner.png" alt="Trekkerspel App Banner" class="banner">
   </header>
   <main>
+    <button id="instructionsBtn" onclick="openInstructions()">Instructies</button>
+    <button id="rulesBtn" onclick="openRules()">Trekkerspel Reglement</button>
     <div id="initialInput">
       <input type="text" id="playerName" placeholder="Spelernaam" onkeydown="handleKey(event, false)" />
       <button onclick="addPlayer()"><i class="fas fa-user-plus"></i> Voeg toe</button>
@@ -63,6 +65,92 @@
           <button onclick="selectTrekker(999)" data-base="999"><i class="fas fa-plane"></i> <span>Gevlogen trekker (999)</span></button>
         </div>
         <button onclick="cancelTrekker()"><i class="fas fa-times"></i> Annuleer</button>
+      </div>
+    </div>
+    <div class="modal" id="instructionsModal">
+      <div class="modal-content">
+        <h2>Instructies</h2>
+        <p>Voeg spelers toe en vul de afstand in kilometers in. Klik daarna op 'Start spel'.</p>
+        <p>Wanneer je een trekker ziet klik je bij je naam op 'Trekker!' en kies je de juiste soort.</p>
+        <p>Gebruik 'Ronde opslaan' om een ronde te bewaren. Met 'Reset scores' zet je alle scores op nul en via 'Herstart spel' begin je opnieuw.</p>
+        <button onclick="closeInstructions()">Sluit</button>
+      </div>
+    </div>
+
+    <div class="modal" id="rulesModal">
+      <div class="modal-content">
+        <h2>Trekkerspel Reglement</h2>
+        <pre>
+Trekkers
+Autospel van Sytse van der Zwan
+Trekker geboden
+Het is trekker geen tractor.
+Trekkers is een gentlemen's game: je speelt eerlijk.
+Het spel begint zodra iedereen zich op het vertrekpunt in de auto
+bevindt. Het spel eindigt pas als de eindbestemming is bereikt.
+Als een iemand een trekker ziet, mag hij/zij de trekker identificeren
+door de soort uit het Puntenoverzicht volledig te noemen. Hierna
+ontvangt hij/zij de bijbehorende punten. Als een trekker tot meerdere
+soorten behoort, moet gekozen worden hoe de trekker wordt geïdentificeerd.
+Degene die als eerste het woord trekker afmaakt krijgt de punten. Ook als je
+bezig was om bijvoorbeeld gereden trekker te zeggen.
+Een inzittende mag een groep van drie of meer trekkers gezamenlijk
+identificeren door de identificatie te beginnen met het woord 'groep'.
+Diegene ontvangt dit puntenaantal vijfmaal voor een juist
+geïdentificeerde groep trekkers.
+Nadat een trekker of groep trekkers juist is geïdentificeerd, wordt deze
+geacht niet meer te bestaan.
+Als iemand een trekker of groep trekkers onjuist identificeert,
+bijvoorbeeld een shovel, verliest diegene alle punten.
+Dit is een grote schande!
+Als er onduidelijkheid is heeft de bedenker van het spel het laatste
+woord. Ook bij het introduceren van nieuw soorten trekkers.
+Mocht het spel te makkelijk worden staan in Bijlage 3 Uitbreidingen.
+Puntenoverzicht
+Soort trekker Punten
+Trekker 1 punt
+Rijdende trekker 3 punten
+Vermomde trekker 6 punten
+Gereden trekker 15 punten
+Gevaren trekker 50 punten & een plek in de Trekker Hall of Fame.
+Gevlogen trekker Je wint het spel & een plek in de Trekker Hall of Fame.
+Opgeschreven door:
+Stan van den Berg
+Jorn van Gijn Versie: 13 oktober 2023
+Trekkers
+Autospel van Sytse van der Zwan
+Bijlage 1. Definities
+Term Definitie
+Trekker Een primair voor de landbouw ontworpen voertuig met vier wielen,
+waarvan de achterwielen groter zijn dan de voorwielen. De onderstaande
+afbeelding is een visueel voorbeeld van een trekker. Niet-kleurenblinden
+opgelet: de kleur kan afwijken van groen.
+Rijdende trekker Trekker die op eigen kracht voortbeweegt.
+Vermomde trekker Een trekker met een visuele afscheiding, waardoor het op het eerste
+gezicht geen trekker lijkt. Dit omvat, maar is niet beperkt tot,
+toeristentreintjes in de stad.
+Gereden trekker Trekker op een oplegger met snelheid.
+Gevaren trekker Trekker op een vaartuig met snelheid.
+Gevlogen trekker Trekker waarvan de wielen de grond niet raken en welke wordt
+voortbewogen door een vliegtuig of helikopter.
+Bijlage 2. Trekker Hall of Fame
+Naam Soort trekker Datum
+Marijke Dijkman Gevaren trekker Onbekend
+Bijlage 3. Uitbreidingen
+Werkende trekker
+(4 punten)
+Trekker die het land bewerkt of doet bewerken. Dit omvat, maar is niet
+beperkt tot, ploegen, oogsten en sproeien.
+Steigerende trekker
+(30 punten)
+Trekker waarvan de voorwielen van de grond komen.
+Ook kan gekozen worden om de volgende regel toe te voegen.
+Het als 2e zeggen van dezelfde trekker verliest men ook alle punten.
+Opgeschreven door:
+Stan van den Berg
+Jorn van Gijn Versie: 13 oktober 2023
+        </pre>
+        <button onclick="closeRules()">Sluit</button>
       </div>
     </div>
   </main>

--- a/index.html
+++ b/index.html
@@ -78,78 +78,61 @@
     </div>
 
     <div class="modal" id="rulesModal">
-      <div class="modal-content">
+      <div class="modal-content rules-content">
         <h2>Trekkerspel Reglement</h2>
-        <pre>
-Trekkers
-Autospel van Sytse van der Zwan
-Trekker geboden
-Het is trekker geen tractor.
-Trekkers is een gentlemen's game: je speelt eerlijk.
-Het spel begint zodra iedereen zich op het vertrekpunt in de auto
-bevindt. Het spel eindigt pas als de eindbestemming is bereikt.
-Als een iemand een trekker ziet, mag hij/zij de trekker identificeren
-door de soort uit het Puntenoverzicht volledig te noemen. Hierna
-ontvangt hij/zij de bijbehorende punten. Als een trekker tot meerdere
-soorten behoort, moet gekozen worden hoe de trekker wordt geïdentificeerd.
-Degene die als eerste het woord trekker afmaakt krijgt de punten. Ook als je
-bezig was om bijvoorbeeld gereden trekker te zeggen.
-Een inzittende mag een groep van drie of meer trekkers gezamenlijk
-identificeren door de identificatie te beginnen met het woord 'groep'.
-Diegene ontvangt dit puntenaantal vijfmaal voor een juist
-geïdentificeerde groep trekkers.
-Nadat een trekker of groep trekkers juist is geïdentificeerd, wordt deze
-geacht niet meer te bestaan.
-Als iemand een trekker of groep trekkers onjuist identificeert,
-bijvoorbeeld een shovel, verliest diegene alle punten.
-Dit is een grote schande!
-Als er onduidelijkheid is heeft de bedenker van het spel het laatste
-woord. Ook bij het introduceren van nieuw soorten trekkers.
-Mocht het spel te makkelijk worden staan in Bijlage 3 Uitbreidingen.
-Puntenoverzicht
-Soort trekker Punten
-Trekker 1 punt
-Rijdende trekker 3 punten
-Vermomde trekker 6 punten
-Gereden trekker 15 punten
-Gevaren trekker 50 punten & een plek in de Trekker Hall of Fame.
-Gevlogen trekker Je wint het spel & een plek in de Trekker Hall of Fame.
-Opgeschreven door:
-Stan van den Berg
-Jorn van Gijn Versie: 13 oktober 2023
-Trekkers
-Autospel van Sytse van der Zwan
-Bijlage 1. Definities
-Term Definitie
-Trekker Een primair voor de landbouw ontworpen voertuig met vier wielen,
-waarvan de achterwielen groter zijn dan de voorwielen. De onderstaande
-afbeelding is een visueel voorbeeld van een trekker. Niet-kleurenblinden
-opgelet: de kleur kan afwijken van groen.
-Rijdende trekker Trekker die op eigen kracht voortbeweegt.
-Vermomde trekker Een trekker met een visuele afscheiding, waardoor het op het eerste
-gezicht geen trekker lijkt. Dit omvat, maar is niet beperkt tot,
-toeristentreintjes in de stad.
-Gereden trekker Trekker op een oplegger met snelheid.
-Gevaren trekker Trekker op een vaartuig met snelheid.
-Gevlogen trekker Trekker waarvan de wielen de grond niet raken en welke wordt
-voortbewogen door een vliegtuig of helikopter.
-Bijlage 2. Trekker Hall of Fame
-Naam Soort trekker Datum
-Marijke Dijkman Gevaren trekker Onbekend
-Bijlage 3. Uitbreidingen
-Werkende trekker
-(4 punten)
-Trekker die het land bewerkt of doet bewerken. Dit omvat, maar is niet
-beperkt tot, ploegen, oogsten en sproeien.
-Steigerende trekker
-(30 punten)
-Trekker waarvan de voorwielen van de grond komen.
-Ook kan gekozen worden om de volgende regel toe te voegen.
-Het als 2e zeggen van dezelfde trekker verliest men ook alle punten.
-Opgeschreven door:
-Stan van den Berg
-Jorn van Gijn Versie: 13 oktober 2023
-        </pre>
+        <h3>Basisspel</h3>
+        <ul>
+          <li>Het is <strong>trekker</strong>, geen tractor.</li>
+          <li>Trekkers is een gentlemen's game: je speelt eerlijk.</li>
+          <li>Het spel start zodra iedereen in de auto zit en eindigt pas bij de eindbestemming.</li>
+          <li>Wie een trekker ziet noemt de soort uit het puntenoverzicht en ontvangt die punten.</li>
+          <li>Behoort een trekker tot meerdere soorten, dan kies je één identificatie.</li>
+          <li>Degene die als eerste het woord "trekker" afmaakt krijgt de punten.</li>
+          <li>Een groep van drie of meer trekkers kan worden gemeld met het woord "groep" en levert vijfmaal de punten op.</li>
+          <li>Correct geïdentificeerde trekkers of groepen tellen daarna niet meer mee.</li>
+          <li>Een foute identificatie (bijv. een shovel) kost alle punten.</li>
+          <li>Bij twijfel beslist de bedenker. Zie ook de uitbreidingen.</li>
+        </ul>
+
+        <h3>Puntenoverzicht</h3>
+        <table>
+          <thead>
+            <tr><th>Soort trekker</th><th>Punten</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Trekker</td><td>1</td></tr>
+            <tr><td>Rijdende trekker</td><td>3</td></tr>
+            <tr><td>Vermomde trekker</td><td>6</td></tr>
+            <tr><td>Gereden trekker</td><td>15</td></tr>
+            <tr><td>Gevaren trekker</td><td>50 + Hall of Fame</td></tr>
+            <tr><td>Gevlogen trekker</td><td>Win het spel + Hall of Fame</td></tr>
+          </tbody>
+        </table>
+
+        <p>Opgeschreven door Stan van den Berg &amp; Jorn van Gijn (versie 13 oktober 2023)</p>
+
+        <h3>Bijlage 1. Definities</h3>
+        <ul>
+          <li><strong>Trekker:</strong> Primair landbouwvoertuig met grote achterwielen. Kleur kan afwijken van groen.</li>
+          <li><strong>Rijdende trekker:</strong> Trekker die op eigen kracht voortbeweegt.</li>
+          <li><strong>Vermomde trekker:</strong> Trekker met visuele afscheiding waardoor het geen trekker lijkt, bijvoorbeeld toeristentreintje.</li>
+          <li><strong>Gereden trekker:</strong> Trekker op een oplegger met snelheid.</li>
+          <li><strong>Gevaren trekker:</strong> Trekker op een vaartuig met snelheid.</li>
+          <li><strong>Gevlogen trekker:</strong> Trekker waarvan de wielen de grond niet raken en voortbewogen wordt door een vliegtuig of helikopter.</li>
+        </ul>
+
+        <h3>Bijlage 2. Trekker Hall of Fame</h3>
+        <ul>
+          <li>Marijke Dijkman &mdash; Gevaren trekker (datum onbekend)</li>
+        </ul>
+
+        <h3>Bijlage 3. Uitbreidingen</h3>
+        <ul>
+          <li><strong>Werkende trekker</strong> (4 punten): trekker die het land bewerkt of doet bewerken, bijvoorbeeld ploegen, oogsten of sproeien.</li>
+          <li><strong>Steigerende trekker</strong> (30 punten): trekker waarvan de voorwielen van de grond komen.</li>
+          <li>Optionele regel: wie als tweede dezelfde trekker roept verliest alle punten.</li>
+        </ul>
+
         <button onclick="closeRules()">Sluit</button>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -205,6 +205,22 @@ function closeModal() {
   document.getElementById('trekkerModal').classList.remove('show');
 }
 
+function openInstructions() {
+  document.getElementById('instructionsModal').classList.add('show');
+}
+
+function closeInstructions() {
+  document.getElementById('instructionsModal').classList.remove('show');
+}
+
+function openRules() {
+  document.getElementById('rulesModal').classList.add('show');
+}
+
+function closeRules() {
+  document.getElementById('rulesModal').classList.remove('show');
+}
+
 function losePoints(name) {
   players[name] = 0;
   persist();
@@ -298,6 +314,10 @@ window.addEventListener('DOMContentLoaded', () => {
   fetchGlobalLeaderboard();
   renderRounds();
   updateInitialList();
+  if (!localStorage.getItem('instructionsSeen')) {
+    openInstructions();
+    localStorage.setItem('instructionsSeen', 'true');
+  }
   if (distanceKm > 0) {
     document.getElementById('distanceKm').value = distanceKm;
     document.querySelector('header').innerHTML = `<img src="trekkerspel_banner.png" class="banner" alt="Banner"/>

--- a/style.css
+++ b/style.css
@@ -112,3 +112,22 @@ input, button {
 .globalLeaderboard li {
   margin: 5px 0;
 }
+
+/* Reglement modal */
+.rules-content {
+  text-align: left;
+  max-height: 70vh;
+  overflow-y: auto;
+}
+.rules-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px 0;
+}
+.rules-content th, .rules-content td {
+  border: 1px solid #ddd;
+  padding: 6px;
+}
+.rules-content th {
+  background: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- add buttons for instructions and reglement
- display instructions on first visit
- implement modals with game instructions and full ruleset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870f54e43b4832dbf8b8a296a487222